### PR TITLE
Fixing #22: Turn Debug off by default.

### DIFF
--- a/src/DMS/Bundle/TwigExtensionBundle/DependencyInjection/Configuration.php
+++ b/src/DMS/Bundle/TwigExtensionBundle/DependencyInjection/Configuration.php
@@ -25,9 +25,9 @@ class Configuration implements ConfigurationInterface
                 ->addDefaultsIfNotSet()
                 ->children()
                     ->booleanNode('i18n')->defaultFalse()->end()
+                    ->booleanNode('debug')->defaultFalse()->end()
                     ->booleanNode('text')->defaultTrue()->end()
                     ->booleanNode('intl')->defaultTrue()->end()
-                    ->booleanNode('debug')->defaultTrue()->end()
                 ->end()
             ->end();
 


### PR DESCRIPTION
Debug extension is deprecated in favor of core plugin in Twig 1.5.
It should be disabled by default and only enabled in earlier versions.
